### PR TITLE
audiorelay: remove dependancy blackhole-2ch as its optional

### DIFF
--- a/Casks/a/audiorelay.rb
+++ b/Casks/a/audiorelay.rb
@@ -16,7 +16,6 @@ cask "audiorelay" do
 
   auto_updates true
   depends_on macos: ">= :high_sierra"
-  depends_on cask: "blackhole-2ch"
 
   app "AudioRelay.app"
 


### PR DESCRIPTION
**Important:** *Do not tick a checkbox if you haven’t performed its action.* Honesty is indispensable for a smooth review process.

_In the following questions `<cask>` is the token of the cask you're submitting._

After making any changes to a cask, existing or new, verify:

- [x] The submission is for [a stable version](https://docs.brew.sh/Acceptable-Casks#stable-versions) or [documented exception](https://docs.brew.sh/Acceptable-Casks#but-there-is-no-stable-version).
- [x] `brew audit --cask --online <cask>` is error-free.
- [x] `brew style --fix <cask>` reports no offenses.

---

AudioRelay indicates there are additional tools required on macOS to route audio as virtual microphones into AudioRelay, and suggest BlackHole as **one of the options**. Currently on Homebrew however it's been added as a required dependency, which adds unnecessary cask to your computer. (Especially a virtual audio app which interacts with the deep lower layers involving system changes and administor privillages)

This PR simply removes the dependency because requiring other tools is a well known fact for macOS if you're working with  audios and the instructions are on the official website if needed. Should there be necessity of guidance after installation however, I'll be happy to add one, if somebody can help me out on manners for it.
